### PR TITLE
🔒 [security fix] Add input length validation to AppValidators.required

### DIFF
--- a/lib/infrastructure/services/app_validators.dart
+++ b/lib/infrastructure/services/app_validators.dart
@@ -1,8 +1,14 @@
 class AppValidators {
-  static String? Function(String?) required(String message) {
+  static String? Function(String?) required(
+    String message, {
+    int maxLength = 255,
+  }) {
     return (String? value) {
       if (value == null || value.trim().isEmpty) {
         return message;
+      }
+      if (value.length > maxLength) {
+        return 'Input too long (max $maxLength characters)';
       }
       return null;
     };

--- a/test/infrastructure/services/app_validators_test.dart
+++ b/test/infrastructure/services/app_validators_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:billing_app/infrastructure/services/app_validators.dart';
+
+void main() {
+  group('AppValidators.required', () {
+    test('should return error message when value is null', () {
+      final validator = AppValidators.required('Required');
+      expect(validator(null), 'Required');
+    });
+
+    test('should return error message when value is empty string', () {
+      final validator = AppValidators.required('Required');
+      expect(validator(''), 'Required');
+    });
+
+    test('should return error message when value is whitespace only', () {
+      final validator = AppValidators.required('Required');
+      expect(validator('   '), 'Required');
+    });
+
+    test('should return null when value is valid', () {
+      final validator = AppValidators.required('Required');
+      expect(validator('Valid Input'), null);
+    });
+
+    test('should return error for very long strings (fixed vulnerability)', () {
+      final validator = AppValidators.required('Required');
+      final longString = 'a' * 256;
+      expect(validator(longString), 'Input too long (max 255 characters)');
+    });
+
+    test('should allow custom maxLength', () {
+      final validator = AppValidators.required('Required', maxLength: 10);
+      expect(validator('a' * 10), null);
+      expect(validator('a' * 11), 'Input too long (max 10 characters)');
+    });
+  });
+}


### PR DESCRIPTION
### 🔒 Security Fix: Missing Input Length Validation

#### 🎯 What:
Added a maximum length check to the `AppValidators.required` validator in `lib/infrastructure/services/app_validators.dart`.

#### ⚠️ Risk:
The previous implementation only checked if the input was null or empty. If left unfixed, the application could be forced to process excessively large strings, potentially leading to:
- Memory exhaustion (DoS)
- Performance degradation
- Database storage issues

#### 🛡️ Solution:
- Modified `AppValidators.required` to accept an optional `maxLength` parameter, defaulting to 255 characters.
- Added logic to return an error message (`'Input too long (max $maxLength characters)'`) if the input length exceeds the specified limit.
- Implemented unit tests in `test/infrastructure/services/app_validators_test.dart` to cover:
    - Null/empty/whitespace checks (existing functionality)
    - Default length limit (255 chars)
    - Custom length limits
- Verified the fix with a standalone Dart script and ensured code formatting with `dart format`.

---
*PR created automatically by Jules for task [11242803604026142282](https://jules.google.com/task/11242803604026142282) started by @RendaniSinyage*