### PR TITLE
🧪 Add testing coverage for ProductBloc

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
+  bloc_test:
+    dependency: "direct dev"
+    description:
+      name: bloc_test
+      sha256: "165a6ec950d9252ebe36dc5335f2e6eb13055f33d56db0eeb7642768849b43d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.7"
   boolean_selector:
     dependency: transitive
     description:
@@ -145,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -185,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -225,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
+  diff_match_patch:
+    dependency: transitive
+    description:
+      name: diff_match_patch
+      sha256: "2efc9e6e8f449d0abe15be240e2c2a3bcd977c8d126cfd70598aee60af35c0a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.1"
   equatable:
     dependency: "direct main"
     description:
@@ -536,6 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.3"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -552,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   objective_c:
     dependency: transitive
     description:
@@ -768,6 +816,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -797,6 +861,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.5"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -845,6 +925,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
@@ -853,6 +941,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:
@@ -941,6 +1037,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,5 +49,7 @@ dev_dependencies:
   build_runner: ^2.4.8
   json_serializable: ^6.7.1
   hive_generator: ^2.0.1
+  bloc_test: ^9.1.7
+  mocktail: ^1.0.4
 flutter:
   uses-material-design: true

--- a/test/application/product/product_bloc_test.dart
+++ b/test/application/product/product_bloc_test.dart
@@ -1,0 +1,229 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:fpdart/fpdart.dart';
+
+import 'package:billing_app/application/product/product_bloc.dart';
+import 'package:billing_app/infrastructure/models/data/product.dart';
+import 'package:billing_app/infrastructure/models/usecases/product_usecases.dart';
+import 'package:billing_app/presentation/components/usecase/usecase.dart';
+import 'package:billing_app/presentation/components/error/failure.dart';
+
+class MockGetProductsUseCase extends Mock implements GetProductsUseCase {}
+class MockAddProductUseCase extends Mock implements AddProductUseCase {}
+class MockUpdateProductUseCase extends Mock implements UpdateProductUseCase {}
+class MockDeleteProductUseCase extends Mock implements DeleteProductUseCase {}
+
+class FakeProduct extends Fake implements Product {}
+class FakeNoParams extends Fake implements NoParams {}
+
+void main() {
+  late ProductBloc productBloc;
+  late MockGetProductsUseCase mockGetProductsUseCase;
+  late MockAddProductUseCase mockAddProductUseCase;
+  late MockUpdateProductUseCase mockUpdateProductUseCase;
+  late MockDeleteProductUseCase mockDeleteProductUseCase;
+
+  const tProduct = Product(
+    id: '1',
+    name: 'Test Product',
+    barcode: '123456789',
+    price: 10.0,
+    stock: 100,
+  );
+
+  final tProductsList = [tProduct];
+  const tFailureMessage = 'Cache failure';
+  const tFailure = CacheFailure(tFailureMessage);
+
+  setUpAll(() {
+    registerFallbackValue(FakeProduct());
+    registerFallbackValue(FakeNoParams());
+  });
+
+  setUp(() {
+    mockGetProductsUseCase = MockGetProductsUseCase();
+    mockAddProductUseCase = MockAddProductUseCase();
+    mockUpdateProductUseCase = MockUpdateProductUseCase();
+    mockDeleteProductUseCase = MockDeleteProductUseCase();
+
+    productBloc = ProductBloc(
+      getProductsUseCase: mockGetProductsUseCase,
+      addProductUseCase: mockAddProductUseCase,
+      updateProductUseCase: mockUpdateProductUseCase,
+      deleteProductUseCase: mockDeleteProductUseCase,
+    );
+  });
+
+  tearDown(() {
+    productBloc.close();
+  });
+
+  test('initial state should be ProductState()', () {
+    expect(productBloc.state, const ProductState());
+  });
+
+  group('LoadProducts', () {
+    blocTest<ProductBloc, ProductState>(
+      'emits [loading, loaded] when GetProductsUseCase succeeds',
+      build: () {
+        when(() => mockGetProductsUseCase(any()))
+            .thenAnswer((_) async => Right(tProductsList));
+        return productBloc;
+      },
+      act: (bloc) => bloc.add(LoadProducts()),
+      expect: () => [
+        const ProductState(status: ProductStatus.loading),
+        ProductState(status: ProductStatus.loaded, products: tProductsList),
+      ],
+      verify: (_) {
+        verify(() => mockGetProductsUseCase(any())).called(1);
+      },
+    );
+
+    blocTest<ProductBloc, ProductState>(
+      'emits [loading, error] when GetProductsUseCase fails',
+      build: () {
+        when(() => mockGetProductsUseCase(any()))
+            .thenAnswer((_) async => const Left(tFailure));
+        return productBloc;
+      },
+      act: (bloc) => bloc.add(LoadProducts()),
+      expect: () => [
+        const ProductState(status: ProductStatus.loading),
+        const ProductState(status: ProductStatus.error, message: tFailureMessage),
+      ],
+      verify: (_) {
+        verify(() => mockGetProductsUseCase(any())).called(1);
+      },
+    );
+  });
+
+  group('AddProduct', () {
+    blocTest<ProductBloc, ProductState>(
+      'emits [loading, success] and then triggers LoadProducts on success',
+      build: () {
+        when(() => mockAddProductUseCase(any()))
+            .thenAnswer((_) async => const Right(unit));
+        when(() => mockGetProductsUseCase(any()))
+            .thenAnswer((_) async => Right(tProductsList));
+        return productBloc;
+      },
+      act: (bloc) => bloc.add(const AddProduct(tProduct)),
+      expect: () => [
+        const ProductState(status: ProductStatus.loading),
+        const ProductState(status: ProductStatus.success, message: 'Product added successfully'),
+        const ProductState(status: ProductStatus.loading),
+        ProductState(status: ProductStatus.loaded, products: tProductsList),
+      ],
+      verify: (_) {
+        verify(() => mockAddProductUseCase(tProduct)).called(1);
+        verify(() => mockGetProductsUseCase(any())).called(1);
+      },
+    );
+
+    blocTest<ProductBloc, ProductState>(
+      'emits [loading, error] when AddProductUseCase fails',
+      build: () {
+        when(() => mockAddProductUseCase(any()))
+            .thenAnswer((_) async => const Left(tFailure));
+        return productBloc;
+      },
+      act: (bloc) => bloc.add(const AddProduct(tProduct)),
+      expect: () => [
+        const ProductState(status: ProductStatus.loading),
+        const ProductState(status: ProductStatus.error, message: tFailureMessage),
+      ],
+      verify: (_) {
+        verify(() => mockAddProductUseCase(tProduct)).called(1);
+        verifyNever(() => mockGetProductsUseCase(any()));
+      },
+    );
+  });
+
+  group('UpdateProduct', () {
+    blocTest<ProductBloc, ProductState>(
+      'emits [loading, success] and then triggers LoadProducts on success',
+      build: () {
+        when(() => mockUpdateProductUseCase(any()))
+            .thenAnswer((_) async => const Right(unit));
+        when(() => mockGetProductsUseCase(any()))
+            .thenAnswer((_) async => Right(tProductsList));
+        return productBloc;
+      },
+      act: (bloc) => bloc.add(const UpdateProduct(tProduct)),
+      expect: () => [
+        const ProductState(status: ProductStatus.loading),
+        const ProductState(status: ProductStatus.success, message: 'Product updated successfully'),
+        const ProductState(status: ProductStatus.loading),
+        ProductState(status: ProductStatus.loaded, products: tProductsList),
+      ],
+      verify: (_) {
+        verify(() => mockUpdateProductUseCase(tProduct)).called(1);
+        verify(() => mockGetProductsUseCase(any())).called(1);
+      },
+    );
+
+    blocTest<ProductBloc, ProductState>(
+      'emits [loading, error] when UpdateProductUseCase fails',
+      build: () {
+        when(() => mockUpdateProductUseCase(any()))
+            .thenAnswer((_) async => const Left(tFailure));
+        return productBloc;
+      },
+      act: (bloc) => bloc.add(const UpdateProduct(tProduct)),
+      expect: () => [
+        const ProductState(status: ProductStatus.loading),
+        const ProductState(status: ProductStatus.error, message: tFailureMessage),
+      ],
+      verify: (_) {
+        verify(() => mockUpdateProductUseCase(tProduct)).called(1);
+        verifyNever(() => mockGetProductsUseCase(any()));
+      },
+    );
+  });
+
+  group('DeleteProduct', () {
+    const tId = '1';
+
+    blocTest<ProductBloc, ProductState>(
+      'emits [loading, success] and then triggers LoadProducts on success',
+      build: () {
+        when(() => mockDeleteProductUseCase(any()))
+            .thenAnswer((_) async => const Right(unit));
+        when(() => mockGetProductsUseCase(any()))
+            .thenAnswer((_) async => Right(tProductsList));
+        return productBloc;
+      },
+      act: (bloc) => bloc.add(const DeleteProduct(tId)),
+      expect: () => [
+        const ProductState(status: ProductStatus.loading),
+        const ProductState(status: ProductStatus.success, message: 'Product deleted successfully'),
+        const ProductState(status: ProductStatus.loading),
+        ProductState(status: ProductStatus.loaded, products: tProductsList),
+      ],
+      verify: (_) {
+        verify(() => mockDeleteProductUseCase(tId)).called(1);
+        verify(() => mockGetProductsUseCase(any())).called(1);
+      },
+    );
+
+    blocTest<ProductBloc, ProductState>(
+      'emits [loading, error] when DeleteProductUseCase fails',
+      build: () {
+        when(() => mockDeleteProductUseCase(any()))
+            .thenAnswer((_) async => const Left(tFailure));
+        return productBloc;
+      },
+      act: (bloc) => bloc.add(const DeleteProduct(tId)),
+      expect: () => [
+        const ProductState(status: ProductStatus.loading),
+        const ProductState(status: ProductStatus.error, message: tFailureMessage),
+      ],
+      verify: (_) {
+        verify(() => mockDeleteProductUseCase(tId)).called(1);
+        verifyNever(() => mockGetProductsUseCase(any()));
+      },
+    );
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `ProductBloc` was addressed by adding `bloc_test` and `mocktail` dependencies, along with setting up mock classes for the relevant use cases (`GetProductsUseCase`, `AddProductUseCase`, `UpdateProductUseCase`, `DeleteProductUseCase`).
📊 **Coverage:** The scenarios now tested include the successful and error paths for `LoadProducts`, `AddProduct`, `UpdateProduct`, and `DeleteProduct` events, verifying that the BLoC correctly transitions states (e.g. from `loading` to `loaded`, `success`, or `error`) and handles side effects (e.g. chaining a `LoadProducts` event after a successful mutation).
✨ **Result:** Test coverage for `ProductBloc` is now substantially improved, increasing the reliability of the feature and creating a strong safety net against future regressions.

---
*PR created automatically by Jules for task [11327548254576582504](https://jules.google.com/task/11327548254576582504) started by @RendaniSinyage*