### PR TITLE
⚡ Optimize Bluetooth Printer Scanning to Execute in Parallel

### DIFF
--- a/lib/application/settings/printer_bloc.dart
+++ b/lib/application/settings/printer_bloc.dart
@@ -45,10 +45,17 @@ class PrinterBloc extends Bloc<PrinterEvent, PrinterState> {
         return;
       }
 
-      bool connected = false;
-      for (var device in devices) {
+      final connectionFutures = devices.map((device) async {
         final success = await repository.connect(device.macAdress);
-        if (success) {
+        return MapEntry(device, success);
+      }).toList();
+
+      final results = await Future.wait(connectionFutures);
+
+      bool connected = false;
+      for (var result in results) {
+        if (result.value) {
+          final device = result.key;
           await repository.savePrinterData(device.macAdress, device.name);
           emit(
             state.copyWith(

--- a/test/benchmark_printer_test.dart
+++ b/test/benchmark_printer_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:print_bluetooth_thermal/print_bluetooth_thermal.dart';
+import 'package:billing_app/infrastructure/repository/printer_repository.dart';
+import 'package:billing_app/application/settings/printer_event.dart';
+import 'package:billing_app/application/settings/printer_state.dart';
+import 'package:billing_app/application/settings/printer_bloc.dart';
+
+class MockPrinterRepository implements PrinterRepository {
+  @override
+  Future<void> clearPrinterData() async {}
+
+  @override
+  Future<bool> connect(String macAddress) async {
+    if (macAddress == 'MAC3') {
+      await Future.delayed(Duration(milliseconds: 500));
+      return true;
+    }
+    await Future.delayed(Duration(milliseconds: 500));
+    return false;
+  }
+
+  @override
+  Future<bool> disconnect() async {
+    return true;
+  }
+
+  @override
+  String? getSavedPrinterMac() => null;
+
+  @override
+  String? getSavedPrinterName() => null;
+
+  @override
+  Future<void> savePrinterData(String mac, String name) async {}
+
+  @override
+  Future<List<BluetoothInfo>> scanDevices() async {
+    return [
+      BluetoothInfo(name: 'Printer1', macAdress: 'MAC1'),
+      BluetoothInfo(name: 'Printer2', macAdress: 'MAC2'),
+      BluetoothInfo(name: 'Printer3', macAdress: 'MAC3'),
+    ];
+  }
+
+  @override
+  Future<void> testPrint(String shopName) async {}
+}
+
+void main() {
+  test('PrinterBloc benchmark', () async {
+    final repo = MockPrinterRepository();
+    final bloc = PrinterBloc(repository: repo);
+
+    final start = DateTime.now();
+    bloc.add(RefreshPrinterEvent());
+
+    await bloc.stream.firstWhere((state) => state.status == PrinterStatus.connected);
+    final end = DateTime.now();
+
+    print('Time taken: ${end.difference(start).inMilliseconds} ms');
+  });
+}


### PR DESCRIPTION
💡 **What:** The optimization implemented is refactoring the sequential loop connection attempts in `PrinterBloc._onRefresh` to concurrent execution using `Future.wait()`.
🎯 **Why:** The performance problem it solves is the stacking delays associated with checking multiple disconnected or unreachable paired devices. If an environment has multiple paired devices and the first few take 500ms to resolve a connection failure, the user has to wait seconds before finding the correct one. Parallelizing the connections evaluates all available Bluetooth paired devices simultaneously.
📊 **Measured Improvement:** In a newly created benchmark test (`test/benchmark_printer_test.dart`), a mockup of three printers where the first two are offline and take 500ms to fail the connection was used.
*   **Baseline:** 1515 ms.
*   **Improvement:** 512 ms.
*   **Change:** ~1003 ms reduction, a 3x speedup on evaluating 3 devices sequentially vs concurrently.

---
*PR created automatically by Jules for task [14488122438187613443](https://jules.google.com/task/14488122438187613443) started by @RendaniSinyage*