### PR TITLE
refactor: 🧹 remove unreachable else branch in checkout page

### DIFF
--- a/lib/presentation/pages/checkout_page.dart
+++ b/lib/presentation/pages/checkout_page.dart
@@ -253,13 +253,6 @@ class _CheckoutPageState extends State<CheckoutPage> {
                                         footer: shopState.shop.footerText,
                                       ),
                                     );
-                              } else {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text('Shop details not loaded'),
-                                    backgroundColor: Colors.red,
-                                  ),
-                                );
                               }
                             },
                             label: 'Print Receipt',

--- a/test/benchmark_printer_test.dart
+++ b/test/benchmark_printer_test.dart
@@ -54,7 +54,8 @@ void main() {
     final start = DateTime.now();
     bloc.add(RefreshPrinterEvent());
 
-    await bloc.stream.firstWhere((state) => state.status == PrinterStatus.connected);
+    await bloc.stream
+        .firstWhere((state) => state.status == PrinterStatus.connected);
     final end = DateTime.now();
 
     print('Time taken: ${end.difference(start).inMilliseconds} ms');

--- a/test/infrastructure/models/data/cart_item_test.dart
+++ b/test/infrastructure/models/data/cart_item_test.dart
@@ -56,7 +56,8 @@ void main() {
         barcode: '999999',
         price: 1000000.0, // 1 million
       );
-      final item = CartItem(product: expensiveProduct, quantity: 1000); // 1 thousand
+      final item =
+          CartItem(product: expensiveProduct, quantity: 1000); // 1 thousand
       expect(item.total, 1000000000.0); // 1 billion
     });
   });

--- a/test/infrastructure/models/usecases/product_usecases_test.dart
+++ b/test/infrastructure/models/usecases/product_usecases_test.dart
@@ -15,7 +15,8 @@ void main() {
   provideDummy<Either<Failure, List<Product>>>(const Right([]));
   // provideDummy for void is tricky, try Right<Failure, void>(null)
   provideDummy<Either<Failure, void>>(Right<Failure, void>(null));
-  provideDummy<Either<Failure, Product>>(const Right(Product(id: 'dummy', name: 'dummy', barcode: 'dummy', price: 0.0)));
+  provideDummy<Either<Failure, Product>>(const Right(
+      Product(id: 'dummy', name: 'dummy', barcode: 'dummy', price: 0.0)));
 
   late MockProductRepository mockRepository;
 
@@ -31,8 +32,10 @@ void main() {
     });
 
     final tProductList = [
-      const Product(id: '1', name: 'Test Product 1', barcode: '123456', price: 10.0),
-      const Product(id: '2', name: 'Test Product 2', barcode: '654321', price: 20.0),
+      const Product(
+          id: '1', name: 'Test Product 1', barcode: '123456', price: 10.0),
+      const Product(
+          id: '2', name: 'Test Product 2', barcode: '654321', price: 20.0),
     ];
 
     test('should get list of products from the repository', () async {
@@ -68,7 +71,8 @@ void main() {
       useCase = AddProductUseCase(mockRepository);
     });
 
-    final tProduct = const Product(id: '1', name: 'Test Product', barcode: '123456', price: 10.0);
+    final tProduct = const Product(
+        id: '1', name: 'Test Product', barcode: '123456', price: 10.0);
 
     test('should add product to the repository', () async {
       // arrange
@@ -103,7 +107,8 @@ void main() {
       useCase = UpdateProductUseCase(mockRepository);
     });
 
-    final tProduct = const Product(id: '1', name: 'Test Product Updated', barcode: '123456', price: 15.0);
+    final tProduct = const Product(
+        id: '1', name: 'Test Product Updated', barcode: '123456', price: 15.0);
 
     test('should update product in the repository', () async {
       // arrange
@@ -117,7 +122,8 @@ void main() {
       verifyNoMoreInteractions(mockRepository);
     });
 
-    test('should return failure when updating product in repository fails', () async {
+    test('should return failure when updating product in repository fails',
+        () async {
       // arrange
       const failure = CacheFailure('Failed to update product');
       when(mockRepository.updateProduct(any))
@@ -152,7 +158,8 @@ void main() {
       verifyNoMoreInteractions(mockRepository);
     });
 
-    test('should return failure when deleting product from repository fails', () async {
+    test('should return failure when deleting product from repository fails',
+        () async {
       // arrange
       const failure = CacheFailure('Failed to delete product');
       when(mockRepository.deleteProduct(any))
@@ -174,7 +181,8 @@ void main() {
     });
 
     const tBarcode = '123456';
-    final tProduct = const Product(id: '1', name: 'Test Product', barcode: '123456', price: 10.0);
+    final tProduct = const Product(
+        id: '1', name: 'Test Product', barcode: '123456', price: 10.0);
 
     test('should get product by barcode from the repository', () async {
       // arrange
@@ -188,7 +196,8 @@ void main() {
       verifyNoMoreInteractions(mockRepository);
     });
 
-    test('should return failure when getting product by barcode fails', () async {
+    test('should return failure when getting product by barcode fails',
+        () async {
       // arrange
       const failure = CacheFailure('Product not found');
       when(mockRepository.getProductByBarcode(any))


### PR DESCRIPTION
🎯 **What:** Removed an unreachable `else` branch inside the `onPressed` callback of the print receipt button in `lib/presentation/pages/checkout_page.dart`.

💡 **Why:** The analyzer flagged this `else` block as dead code. The `shopState` is guaranteed to be inferred correctly within that context, rendering the error-handling branch unreachable. Removing it reduces nesting, eliminates analyzer warnings, and improves overall code readability and maintainability without altering application behavior.

✅ **Verification:**
1. Ran `flutter pub get` and `dart analyze` to confirm that the `dead_code` warning is resolved and no new issues are introduced.
2. Formatted the codebase using `dart format .`.
3. Ran `flutter test` to ensure all existing functionality and unit tests remain intact.

✨ **Result:** A cleaner `checkout_page.dart` free of static analysis warnings with slightly simpler UI logic.

---
*PR created automatically by Jules for task [18121530105674490533](https://jules.google.com/task/18121530105674490533) started by @RendaniSinyage*