### PR TITLE
fix: 🔒 Sentinel: Add max length check to price validator

### DIFF
--- a/lib/infrastructure/services/app_validators.dart
+++ b/lib/infrastructure/services/app_validators.dart
@@ -14,9 +14,12 @@ class AppValidators {
     };
   }
 
-  static String? price(String? value) {
+  static String? price(String? value, {int maxLength = 255}) {
     if (value == null || value.trim().isEmpty) {
       return 'Please enter a price';
+    }
+    if (value.length > maxLength) {
+      return 'Input too long (max $maxLength characters)';
     }
     if (double.tryParse(value) == null) {
       return 'Please enter a valid number';


### PR DESCRIPTION
**What:**
Added an input length limit (`maxLength = 255`) to the `AppValidators.price` function.

**Risk:**
Without a maximum length check on price inputs, passing extremely long strings to `double.tryParse` and `double.parse` could potentially freeze the UI thread and lead to Denial-of-Service (DoS) behavior. 

**Solution:**
Added an optional `maxLength` parameter to the `price` function that returns an error early if the input exceeds the given limit (defaults to 255). This approach leverages Dart's named optional parameter flexibility to ensure backward compatibility with existing usage in `add_product_page.dart` and `edit_product_page.dart`.

---
*PR created automatically by Jules for task [4226091624400842553](https://jules.google.com/task/4226091624400842553) started by @RendaniSinyage*