### PR TITLE
Fix missing and ambiguous imports in manager pages

### DIFF
--- a/lib/application/restaurant/manager/income/statistics/statistics_notifier.dart
+++ b/lib/application/restaurant/manager/income/statistics/statistics_notifier.dart
@@ -1,5 +1,5 @@
 import 'package:rokctapp/domain/interface/manager_users.dart';
-import 'package:rokctapp/infrastructure/models/response/statistics_order_response.dart';
+import 'package:rokctapp/infrastructure/models/response/manager/statistics_order_response.dart';
 import 'package:rokctapp/infrastructure/models/response/statistics_income_response.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/application/restaurant/manager/income/statistics/statistics_state.dart
+++ b/lib/application/restaurant/manager/income/statistics/statistics_state.dart
@@ -1,5 +1,5 @@
 import 'package:rokctapp/infrastructure/models/response/statistics_income_response.dart';
-import 'package:rokctapp/infrastructure/models/response/statistics_order_response.dart';
+import 'package:rokctapp/infrastructure/models/response/manager/statistics_order_response.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'statistics_state.freezed.dart';

--- a/lib/presentation/pages/income/manager/more_orders.dart
+++ b/lib/presentation/pages/income/manager/more_orders.dart
@@ -6,12 +6,12 @@ import 'package:flutter_remix/flutter_remix.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
-import 'package:rokctapp/application/restaurant/manager/income/statistics/statistics_notifier.dart';
 import 'package:rokctapp/presentation/components/filter/manager_filter_screen.dart';
 import 'package:rokctapp/presentation/components/helper/modal_wrap.dart';
 import 'package:rokctapp/presentation/theme/app_style.dart';
 
-import 'package:rokctapp/infrastructure/services/utils/app_helpers.dart';
+import 'package:rokctapp/application/restaurant/manager/income/statistics/statistics_provider.dart';
+import 'package:rokctapp/infrastructure/services/utils/app_helpers.dart' as help;
 
 class MoreOrders extends ConsumerStatefulWidget {
   final DateTime? endTime;
@@ -258,10 +258,11 @@ class _MoreOrdersState extends ConsumerState<MoreOrders> {
                                     children: [
                                       Text(
                                         help.AppHelpers.numberFormat(
-                                          ref
-                                              .watch(statisticsProvider)
-                                              .listOfOrder[i]
-                                              .price,
+                                          number:
+                                              ref
+                                                  .watch(statisticsProvider)
+                                                  .listOfOrder[i]
+                                                  .price,
                                         ),
                                         style: AppStyle.interSemi(
                                           size: 12,

--- a/lib/presentation/pages/order_history/manager/order_history.dart
+++ b/lib/presentation/pages/order_history/manager/order_history.dart
@@ -13,7 +13,8 @@ import 'package:rokctapp/presentation/components/tab_bars/custom_app_bar.dart';
 import 'package:rokctapp/presentation/components/filter/manager_filter_screen.dart';
 import 'package:rokctapp/presentation/components/tab_bars/manager/custom_tab_bar.dart';
 
-import 'package:rokctapp/infrastructure/services/utils/app_helpers.dart';
+import 'package:rokctapp/application/order/manager/order_provider.dart';
+import 'package:rokctapp/infrastructure/services/utils/app_helpers.dart' as help;
 import 'package:rokctapp/presentation/pages/order_history/manager/canceled_orders_body.dart';
 import 'package:rokctapp/presentation/pages/order_history/manager/delivered_order_body.dart';
 

--- a/lib/presentation/theme/app_style.dart
+++ b/lib/presentation/theme/app_style.dart
@@ -76,6 +76,7 @@ abstract class AppStyle {
   static const Color orderStatusProgressBack = Color(0xFFE7E7E7);
   static const Color shadow = Color(0x3FD8D8D8);
   static const Color shadowBottom = Color(0x33000000);
+  static const Color buttonFontColor = Color(0xFFFFFFFF);
 
   // --- Merged from Driver & Manager ---
   static const Color progressColor = Color(0xffF26110);


### PR DESCRIPTION
- Resolved ambiguity for 'statisticsProvider' and 'orderProvider' by adding correct manager-specific imports.
- Added 'as help' alias to 'app_helpers.dart' import to match existing usage.
- Added missing 'buttonFontColor' constant to 'AppStyle'.
- Updated 'StatisticsOrder' and related models to use the correct manager-specific versions.
- Fixed 'numberFormat' usage in 'more_orders.dart' by using named 'number' parameter.
- Verified fixes with 'flutter analyze'.